### PR TITLE
[#5] option for number of result to show

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,10 @@ import (
 	"time"
 )
 
+const (
+	DefaultNumOfResultToShow = 3
+)
+
 func departureTime(departure string) (int, int) {
 	ret, _ := regexp.MatchString("^[0-9]{1,2}:[0-9]{1,2}$", departure)
 	var hour int
@@ -81,21 +85,22 @@ func main() {
 	flag.Parse()
 	hour, minute := departureTime(departure)
 	timetable := createTimetable(getSelector())
+	numOfResult := DefaultNumOfResultToShow
 
 	arrivals := timetable[hour]
-	result := make([]int, 0, 3)
+	result := make([]int, 0, numOfResult)
 	for _, v := range arrivals {
 		if v > minute {
 			result = append(result, v)
-			if len(result) >= 3 {
+			if len(result) >= numOfResult {
 				break
 			}
 		}
 	}
 	printTimes(hour, result)
 
-	if hour != 23 && len(result) < 3 {
-		max := 3 - len(result)
+	if hour != 23 && len(result) < numOfResult {
+		max := numOfResult - len(result)
 		arrivals = timetable[hour+1]
 		result2 := make([]int, 0, max)
 		for _, v := range arrivals {

--- a/main.go
+++ b/main.go
@@ -85,11 +85,13 @@ func printTimes(times []Time) {
 
 func main() {
 	var departure string
+	var numOfResult int
 	flag.StringVar(&departure, "t", "", "specify departure time.")
+	flag.IntVar(&numOfResult, "n", DefaultNumOfResultToShow, "specify amount of result.")
 	flag.Parse()
+
 	hour, minute := departureTime(departure)
 	timetable := createTimetable(getSelector())
-	numOfResult := DefaultNumOfResultToShow
 
 	result := make([]Time, 0, numOfResult)
 	for _, v := range timetable {

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/PuerkitoBio/goquery"
+	"os"
 	"regexp"
 	"strconv"
 	"time"
@@ -89,6 +90,11 @@ func main() {
 	flag.StringVar(&departure, "t", "", "specify departure time.")
 	flag.IntVar(&numOfResult, "n", DefaultNumOfResultToShow, "specify amount of result.")
 	flag.Parse()
+
+	if numOfResult < 0 {
+		fmt.Fprintf(os.Stderr, "parameter for -n must be greater than 0.\n")
+		os.Exit(2)
+	}
 
 	hour, minute := departureTime(departure)
 	timetable := createTimetable(getSelector())


### PR DESCRIPTION
# This PR is for issue #5
# Updates
- -n で表示件数を指定できる機能を追加
  - 9999等のでかい数字をいれると最後（終バス）まで表示
  - 0以下を指定するとエラー
  - デフォルト（パラメータ指定なしの場合）の値は 3
- タイムテーブルを一次元配列で表せるように少し構造を変更
# Status
- [x] 実装
- [x] go test が通る
